### PR TITLE
Add type constraint to please the 4.04.0 compiler

### DIFF
--- a/src/logs.ml
+++ b/src/logs.ml
@@ -114,7 +114,7 @@ module Tag = struct
 
   type def_e = Def : 'a def -> def_e
 
-  let list = ref []
+  let list = ref ([] : def_e list)
   let uid =
     let id = ref (-1) in
     fun () -> incr id; !id


### PR DESCRIPTION
Because of an obscure fix to an obscure bug in 4.02 and earlier, the 4.03 and 4.04 compilers will reject this code if you don't explicitly state the type of the elements (not) stored into the `list` variable. This fix should be compatible with all earlier OCaml versions.

See http://caml.inria.fr/mantis/view.php?id=6752