### PR TITLE
Add support for threads 2

### DIFF
--- a/_tags
+++ b/_tags
@@ -5,6 +5,7 @@ true : bin_annot, safe_string
 <src/logs_cli*> : package(cmdliner)
 <src/logs_lwt*> : package(lwt)
 <src/logs_top*> : package(compiler-libs.toplevel)
+<src/logs_threaded*> : thread, package(threads)
 <test> : include
 <test/tool*> : package(fmt), package(fmt.tty), package(fmt.cli), \
                package(cmdliner)
@@ -14,3 +15,4 @@ true : bin_annot, safe_string
                    package(fmt.tty)
 <test/tags*> : package(mtime.clock.os)
 <test/test_multi*> : package(fmt), package(fmt.tty)
+<test/test_threaded*> : thread, package(threads), package(fmt)

--- a/pkg/META
+++ b/pkg/META
@@ -49,6 +49,17 @@ package "lwt" (
   exists_if = "logs_lwt.cma"
 )
 
+package "threaded" (
+  description = "Thread safe logging"
+  version = "%%VERSION_NUM%%
+  requires = "logs threads"
+  archive(byte) = "logs_threaded.cma"
+  archive(native) = "logs_threaded.cmxa"
+  plugin(byte) = "logs_threaded.cma"
+  plugin(native) = "logs_threaded.cmxs"
+  exists_if = "logs_threaded.cma"
+)
+
 package "top" (
   description = "Logs toplevel support"
   version = "%%VERSION_NUM%%"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -7,6 +7,7 @@ let jsoo = Conf.with_pkg "js_of_ocaml"
 let cmdliner = Conf.with_pkg "cmdliner"
 let fmt = Conf.with_pkg "fmt"
 let lwt = Conf.with_pkg "lwt"
+let threads = Conf.with_pkg "threads"
 
 let () =
   Pkg.describe "logs" @@ fun c ->
@@ -14,12 +15,14 @@ let () =
   let cmdliner = Conf.value c cmdliner in
   let fmt = Conf.value c fmt in
   let lwt = Conf.value c lwt in
+  let threads = Conf.value c threads in
   Ok [ Pkg.mllib "src/logs.mllib";
        Pkg.mllib ~cond:fmt "src/logs_fmt.mllib";
        Pkg.mllib ~cond:jsoo "src/logs_browser.mllib";
        Pkg.mllib ~cond:cmdliner "src/logs_cli.mllib";
        Pkg.mllib ~cond:lwt "src/logs_lwt.mllib";
        Pkg.mllib ~cond:fmt ~api:[] "src/logs_top.mllib";
+       Pkg.mllib ~cond:threads "src/logs_threaded.mllib";
        Pkg.lib "src/logs_top_init.ml";
        Pkg.lib "src/logs_fmt_top_init.ml";
        Pkg.doc "test/tool.ml";
@@ -31,5 +34,6 @@ let () =
        Pkg.test "test/test_multi";
 (*       Pkg.test "test/test_browser.js";
          Pkg.test "test/test_browser.html"; *)
+       Pkg.test "test/test_threaded";
        Pkg.test "test/test_lwt";
  ]

--- a/src/logs.mli
+++ b/src/logs.mli
@@ -368,6 +368,12 @@ val warn_count : unit -> int
 (** [warn_count ()] is the number of messages logged with level
     [Warning] across all sources. *)
 
+(** {1 Thread safety} *)
+
+val set_mutex : lock:(unit -> unit) -> unlock:(unit -> unit) -> unit
+(** [set_mutex ~lock ~unlock] sets the mutex functions.
+    [lock] is called before and [unlock] after any thread-unsafe operations. *)
+
 (** {1:basics Basics}
 
     {2:logging Logging}

--- a/src/logs_threaded.ml
+++ b/src/logs_threaded.ml
@@ -1,4 +1,4 @@
-let () =
+let enable () =
   let lock = Mutex.create () in
   let lock () = Mutex.lock lock
   and unlock () = Mutex.unlock lock in

--- a/src/logs_threaded.ml
+++ b/src/logs_threaded.ml
@@ -1,0 +1,5 @@
+let () =
+  let lock = Mutex.create () in
+  let lock () = Mutex.lock lock
+  and unlock () = Mutex.unlock lock in
+  Logs.set_mutex ~lock ~unlock

--- a/src/logs_threaded.mli
+++ b/src/logs_threaded.mli
@@ -1,0 +1,6 @@
+(** Thread safe logging.
+
+    Linking this library will make Logs thread safe by using a global lock.
+    Setting [Logs.set_mutex] will override this.
+
+    {e %%VERSION%% - {{:%%PKG_HOMEPAGE%%}homepage}} *)

--- a/src/logs_threaded.mli
+++ b/src/logs_threaded.mli
@@ -1,6 +1,7 @@
 (** Thread safe logging.
 
-    Linking this library will make Logs thread safe by using a global lock.
-    Setting [Logs.set_mutex] will override this.
-
     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%%}homepage}} *)
+
+val enable : unit -> unit
+(** [enable ()] enables thread-safe logging.
+    It is done setting [Logs.set_mutex], setting it again will remove thread-safety. *)

--- a/src/logs_threaded.mllib
+++ b/src/logs_threaded.mllib
@@ -1,0 +1,1 @@
+Logs_threaded

--- a/test/test_threaded.ml
+++ b/test/test_threaded.ml
@@ -4,6 +4,7 @@ let loop s =
   done
 
 let () =
+  Logs_threaded.enable ();
   Logs.set_level (Some Logs.Debug);
   Logs.set_reporter (Logs_fmt.reporter ());
   let t1 = Thread.create loop "aaaa" in

--- a/test/test_threaded.ml
+++ b/test/test_threaded.ml
@@ -1,0 +1,13 @@
+let loop s =
+  for _ = 0 to 10 do
+    Logs.info (fun f -> f "%s.%s" s s)
+  done
+
+let () =
+  Logs.set_level (Some Logs.Debug);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  let t1 = Thread.create loop "aaaa" in
+  let t2 = Thread.create loop "bbbb" in
+  loop "cccc";
+  Thread.join t1;
+  Thread.join t2


### PR DESCRIPTION
Alternative to https://github.com/dbuenzli/logs/pull/27.

Add a `logs.threaded` library and the function `Logs_threaded.enable ()` function to enable thread-safe logging.

It is implemented by adding `Logs.set_mutex` which sets the `lock` and `unlock` functions that can be set by `Logs_threaded.enable`. They do nothing by default.