### PR TITLE
Allow a CLI app to set its default log level in `Logs_cli.level`

### DIFF
--- a/src/logs_cli.ml
+++ b/src/logs_cli.ml
@@ -8,7 +8,7 @@ open Cmdliner
 
 let strf = Format.asprintf
 
-let level ?env ?docs () =
+let level ?(default=Some Logs.Warning) ?env ?docs () =
   let vopts =
     let doc = "Increase verbosity. Repeatable, but more than twice does
                not bring more."
@@ -17,7 +17,7 @@ let level ?env ?docs () =
   in
   let verbosity =
     let enum =
-      [ "warning", None; (* Hack for the option's absent rendering *)
+      [ Logs.level_to_string default, None; (* Hack for the option's absent rendering *)
         "quiet", Some None;
         "error", Some (Some Logs.Error);
         "warning", Some (Some Logs.Warning);
@@ -41,7 +41,7 @@ let level ?env ?docs () =
     | Some verbosity -> verbosity
     | None ->
         match List.length vopts with
-        | 0 -> Some Logs.Warning
+        | 0 -> default
         | 1 -> Some Logs.Info
         | n -> Some Logs.Debug
   in

--- a/src/logs_cli.mli
+++ b/src/logs_cli.mli
@@ -12,9 +12,9 @@
 
 (** {1 Options for setting the report level} *)
 
-val level : ?env:Cmdliner.Arg.env -> ?docs:string -> unit ->
+val level : ?default:Logs.level option -> ?env:Cmdliner.Arg.env -> ?docs:string -> unit ->
     Logs.level option Cmdliner.Term.t
-(** [level ?env ?docs ()] is a term for three {!Cmdliner} options that
+(** [level ?default ?env ?docs ()] is a term for three {!Cmdliner} options that
     can be used with {!Logs.set_level}.  The options are documented
     under [docs] (defaults to the default of {!Cmdliner.Arg.info}).
 
@@ -28,7 +28,7 @@ val level : ?env:Cmdliner.Arg.env -> ?docs:string -> unit ->
     {- [-q] or [--quiet], the value of the term is [None]. Takes
        over the [-v] and [--verbosity] options.}
     {- If both options are absent the default value is
-       [Some Logs.warning]}}
+       [default] if provided, otherwise [Some Logs.Warning]}.}
 
     If [env] is provided, the default value in case all options are
     absent can be overridden by the corresponding environment


### PR DESCRIPTION
I'm adding support to several tools using logs and fmt of the tty, colors, and verbosity integration with cmdliner, fmt, and logs. Some of these tools were defaulting to the info error level  (instead of `Logs_cli` default to `Some Logs.Warning`).
It is tricky to keep that behavior with `Logs_cli.level` because it doesn't return whether the error level was set by the user or defaulted to `Some Logs.Warning`. The suggested workaround to use `env` seem to indicate that I could set that parameter, test the existence of the env var, do a `putenv` if it isn't set, and then call `Logs_cli.level`. Maybe I've missed something, but an easy and nice way is to add an optional `default` parameter (that still defaults to `Some Logs.Warning`) to `Logs_cli.level`. Using `Logs.level_to_string default` also allows the help page to report the app chosen default level.