### PR TITLE
opam: fix cmdliner constraint

### DIFF
--- a/opam
+++ b/opam
@@ -16,12 +16,14 @@ depends: [
 depopts: [
   "js_of_ocaml"
   "fmt"
-  "cmdliner" {>= "1.0.4."}
+  "cmdliner"
   "lwt"
   "base-threads"
 ]
 conflicts: [
-  "js_of_ocaml" { < "3.3.0" } ]
+  "js_of_ocaml" { < "3.3.0" } 
+  "cmdliner" {< "1.0.0"}
+]
 
 build: [[
   "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
The bound needs to go in the conflicts, otherwise it has no effect (also the value was wrong).
I believe the correct bound there is >= 1.0.0, so a conflict with < 1.0.0 should do.

Corresponding PR on opam-repo, where we can check the lower-bounds CI is: https://github.com/ocaml/opam-repository/pull/20247